### PR TITLE
Change in read endpoint response

### DIFF
--- a/employee-service/handlers/read.go
+++ b/employee-service/handlers/read.go
@@ -9,6 +9,7 @@ import (
 )
 
 func Read(context *gin.Context) {
+	id, _ := context.Get("employee_id")
 	var rows []models.Employee
 
 	err := configs.Database.Table("employees").Find(&rows).Error
@@ -36,5 +37,6 @@ func Read(context *gin.Context) {
 	context.JSON(http.StatusOK, gin.H{
 		"message": "All employees details are fetched successfully.",
 		"data":    rows,
+		"employee_id": id,
 	})
 }


### PR DESCRIPTION
Explanation: To avoid deleting the user data from the device in the employees table, the currently logged-in user's employee ID is passed in the response, which is stored on the client side for further processing. 

Change in endpoint: /employees/read
